### PR TITLE
added snack bar interceptor and service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,9 @@ import { AuthorizationHttpInterceptorService } from './services/AuthHttpIntercep
 import { SpinnerComponent } from './loading-spinner/spinner/spinner.component';
 import { SpinnerService } from './services/SpinnerService/spinner-service.service';
 import { SpinnerHttpinterceptorService } from './services/SpinnerHttpInterceptor/spinner-httpinterceptor.service';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { SnackbarHttpService } from './services/SnackBarHttpInterceptor/snackbar-http.service';
+import { CustomSnackbarComponent } from './custom-snackbar/custom-snackbar.component';
 
 @NgModule({
   declarations: [
@@ -48,7 +51,9 @@ import { SpinnerHttpinterceptorService } from './services/SpinnerHttpInterceptor
     MatCheckboxModule,
     HttpClientModule,
     MatTableModule,
-    SpinnerComponent
+    SpinnerComponent,
+    MatSnackBarModule,
+    CustomSnackbarComponent
   ],
   providers: [ 
     SpinnerService,
@@ -61,6 +66,11 @@ import { SpinnerHttpinterceptorService } from './services/SpinnerHttpInterceptor
       provide: HTTP_INTERCEPTORS,
       useClass: SpinnerHttpinterceptorService,
       multi:true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: SnackbarHttpService,
+      multi: true
     }
   ],
   bootstrap: [AppComponent]

--- a/src/app/custom-snackbar/custom-snackbar.component.css
+++ b/src/app/custom-snackbar/custom-snackbar.component.css
@@ -1,0 +1,5 @@
+.custom-snackbar{
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+}

--- a/src/app/custom-snackbar/custom-snackbar.component.html
+++ b/src/app/custom-snackbar/custom-snackbar.component.html
@@ -1,0 +1,4 @@
+<div class="custom-snackbar">
+    <div>{{emoji}}</div>
+    <div class="message">{{ message }}</div>
+  </div>

--- a/src/app/custom-snackbar/custom-snackbar.component.spec.ts
+++ b/src/app/custom-snackbar/custom-snackbar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CustomSnackbarComponent } from './custom-snackbar.component';
+
+describe('CustomSnackbarComponent', () => {
+  let component: CustomSnackbarComponent;
+  let fixture: ComponentFixture<CustomSnackbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CustomSnackbarComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CustomSnackbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/custom-snackbar/custom-snackbar.component.ts
+++ b/src/app/custom-snackbar/custom-snackbar.component.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-custom-snackbar',
+  templateUrl: './custom-snackbar.component.html',
+  styleUrls: ['./custom-snackbar.component.css'],
+  standalone:true,
+  imports: [CommonModule]
+})
+/**
+ * CustomSnackbarComponent is a component that displays a custom snackbar with an icon and a message.
+ * It receives the icon and message data from the MAT_SNACK_BAR_DATA injection token.
+ * The icon can be 'x' for error, 'tick' for success, or 'i' for information.
+ * The component sets an emoji based on the icon value and displays it along with the message.
+ */
+export class CustomSnackbarComponent implements OnInit {
+  @Input() icon: string = 'x';
+  @Input() message: string = '';
+  emoji:string | undefined ;
+  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+
+  ngOnInit(): void {
+    this.icon = this.data.icon; // Set the icon value from the data passed by the service
+    this.message = this.data.message; // Set the message value from the data passed by the service
+
+    //TODO: find a better way to do this but it will do temporary
+    switch (this.icon) {
+      case 'x':
+        this.emoji= '❌';
+        break;
+      case 'tick':
+        this.emoji= '✅';
+        break;
+      case 'i':
+        this.emoji='info';
+        break;
+      default:
+        this.emoji= ''; // Return an empty string for unknown icons or handle it as per your requirement
+        break;
+   }
+   console.log(this.data,this.emoji);
+  }
+}

--- a/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.spec.ts
+++ b/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SnackbarHttpService } from './snackbar-http.service';
+
+describe('SnackbarHttpService', () => {
+  let service: SnackbarHttpService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SnackbarHttpService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.ts
+++ b/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.ts
@@ -24,10 +24,10 @@ export class SnackbarHttpService {
     return next.handle(req).pipe(
       tap(
         (event: HttpEvent<any>): void => {
-          if (event instanceof HttpResponse && event.status >= 200 && event.status < 300) {
-            // Show a success snackbar for status codes in the range 200-299
-            this.snackbarService.showSuccessSnackbar(`Request finished with http code ${event.status}`, config);
-          }
+          // // Show a success snackbar for status codes in the range 200-299
+          // if (event instanceof HttpResponse && event.status >= 200 && event.status < 300) {
+          //   this.snackbarService.showSuccessSnackbar(`Request finished with http code ${event.status}`, config);
+          // }
 
         },
         (error: HttpErrorResponse) => {

--- a/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.ts
+++ b/src/app/services/SnackBarHttpInterceptor/snackbar-http.service.ts
@@ -1,0 +1,42 @@
+import { HttpEvent, HttpHandler, HttpRequest, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { tap, finalize } from 'rxjs/operators';
+import { SnackbarService } from '../SnackBarService/snack-bar-service.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+//TODO: handle more cases, more specifically
+/**
+ * Service that intercepts HTTP requests and displays a snackbar notification based on the response status code.
+ */
+export class SnackbarHttpService {
+
+  constructor(private snackbarService: SnackbarService) { }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const config = {
+      duration: 3000,
+    };
+
+    return next.handle(req).pipe(
+      tap(
+        (event: HttpEvent<any>): void => {
+          if (event instanceof HttpResponse && event.status >= 200 && event.status < 300) {
+            // Show a success snackbar for status codes in the range 200-299
+            this.snackbarService.showSuccessSnackbar(`Request finished with http code ${event.status}`, config);
+          }
+
+        },
+        (error: HttpErrorResponse) => {
+          if (error.status >= 400) {
+            // Show an error snackbar for status codes greater than or equal to 400
+            this.snackbarService.showErrorSnackbar(`Request failed with http code ${error.status}`, config);
+          }
+        }
+      )
+    );
+  }
+}

--- a/src/app/services/SnackBarService/snack-bar-service.service.spec.ts
+++ b/src/app/services/SnackBarService/snack-bar-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SnackBarServiceService } from './snack-bar-service.service';
+
+describe('SnackBarServiceService', () => {
+  let service: SnackBarServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SnackBarServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/SnackBarService/snack-bar-service.service.ts
+++ b/src/app/services/SnackBarService/snack-bar-service.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { CustomSnackbarComponent } from 'src/app/custom-snackbar/custom-snackbar.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * Service for displaying snackbars.
+ * you can customize the component in custom-snackbar.component
+ * you can pass options by creating an object Partial<MatSnackBarConfig> and pass any of the options. if some are not present, they will default to the ones in the "defaultOptions"
+ * the panelClass can be used to put a style on the pop-up, and then can be used in css, see more here:
+ * https://material.angular.io/components/snack-bar/examples#snack-bar-annotated-component
+ * https://material.angular.io/components/snack-bar/examples#snack-bar-component
+ */
+export class SnackbarService {
+
+  constructor(private snackBar: MatSnackBar) { }
+
+
+  private showSnackbar(message: string, icon: string, options?: Partial<MatSnackBarConfig>): void {
+    const defaultOptions: MatSnackBarConfig = {
+      duration: 3000,
+      horizontalPosition: 'center',
+      verticalPosition: 'top',
+      panelClass: '',
+      politeness: 'assertive',
+    };
+
+    const mergedOptions = { ...defaultOptions, ...options };
+    const { duration, horizontalPosition, verticalPosition, panelClass, politeness } = mergedOptions;
+
+    this.snackBar.openFromComponent(CustomSnackbarComponent, {
+      data: { message, icon }, 
+      duration: duration,
+      horizontalPosition: horizontalPosition,
+      verticalPosition: verticalPosition,
+      panelClass: panelClass,
+      politeness: politeness
+    });
+  }
+
+  showInfoSnackbar(message: string, options?: Partial<MatSnackBarConfig>): void {
+    const icon = 'i';
+    this.showSnackbar(message, icon, options);
+  }
+
+  showErrorSnackbar(message: string, options?: Partial<MatSnackBarConfig>): void {
+    const icon = 'x';
+    this.showSnackbar(message, icon, options);
+  }
+
+  showSuccessSnackbar(message: string, options?: Partial<MatSnackBarConfig>): void {
+    const icon = 'tick';
+    this.showSnackbar(message, icon, options);
+  }
+}

--- a/src/app/services/SpinnerHttpInterceptor/spinner-httpinterceptor.service.ts
+++ b/src/app/services/SpinnerHttpInterceptor/spinner-httpinterceptor.service.ts
@@ -8,7 +8,6 @@ import {
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { SpinnerService } from '../SpinnerService/spinner-service.service';
-import { LocalStorageService } from '../LocalStorageService/local-storage.service';
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +19,7 @@ import { LocalStorageService } from '../LocalStorageService/local-storage.servic
  */
 export class SpinnerHttpinterceptorService implements HttpInterceptor{
 
-  constructor(private spinnerService:SpinnerService, private localStorageService:LocalStorageService) { }
+  constructor(private spinnerService:SpinnerService) { }
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     
     this.spinnerService.show();


### PR DESCRIPTION
Added snack bar http interceptor and snack bar service
The snack bar interceptor has commited code for the case when the request comes back in the range of 200 and 300, but when it will get an error, it will show an error snack.
uncomment the code to see it in action

The snack bar config offers a wide range of customization, from the message, to the vertical and horizontal pozition. You can look in the code to see how to use the config options, but it is not mandatory and it will default back to 
``` ts
const defaultOptions: MatSnackBarConfig = {
      duration: 3000,
      horizontalPosition: 'center',
      verticalPosition: 'top',
      panelClass: '',
      politeness: 'assertive',
    };